### PR TITLE
feat : 기존 검색어 저장 기능 수정 및 연관검색어 기능 추가

### DIFF
--- a/src/main/java/com/farm/pedia/global/exception/AbstractExceptionHandler.java
+++ b/src/main/java/com/farm/pedia/global/exception/AbstractExceptionHandler.java
@@ -2,8 +2,8 @@ package com.farm.pedia.global.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
 import lombok.extern.slf4j.Slf4j;
+
 
 @Slf4j
 public abstract class AbstractExceptionHandler {

--- a/src/main/java/com/farm/pedia/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/farm/pedia/global/exception/CustomExceptionHandler.java
@@ -1,24 +1,19 @@
 package com.farm.pedia.global.exception;
 
 import jakarta.validation.ConstraintViolationException;
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.List;
-import java.util.Map;
-
-@ControllerAdvice
+@RestControllerAdvice
+@Slf4j
 public class CustomExceptionHandler extends AbstractExceptionHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(CustomExceptionHandler.class);
-
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<List<Map<String, Object>>> handleConstraintViolationException(ConstraintViolationException ex) {
-        log.error("Constraint violation exception: ", ex);  // 로그 예외 기록 - 공백 검색 시
-        return new ResponseEntity<>(List.of(), HttpStatus.OK);
+    public ResponseEntity<String> handleConstraintViolationException(ConstraintViolationException ex) {
+        log.error("Constraint violation exception: ", ex);
+        return handleBadRequest(ex);
     }
 }

--- a/src/main/java/com/farm/pedia/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/farm/pedia/global/exception/CustomExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.farm.pedia.global.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+@ControllerAdvice
+public class CustomExceptionHandler extends AbstractExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomExceptionHandler.class);
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<List<Map<String, Object>>> handleConstraintViolationException(ConstraintViolationException ex) {
+        log.error("Constraint violation exception: ", ex);  // 로그 예외 기록 - 공백 검색 시
+        return new ResponseEntity<>(List.of(), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/farm/pedia/searchHistory/controller/SearchHistoryController.java
+++ b/src/main/java/com/farm/pedia/searchHistory/controller/SearchHistoryController.java
@@ -1,6 +1,7 @@
 package com.farm.pedia.searchHistory.controller;
 
 import com.farm.pedia.auth.config.UserLogin;
+import com.farm.pedia.searchHistory.domain.SearchResults;
 import com.farm.pedia.searchHistory.service.SearchHistoryService;
 import com.farm.pedia.user.domain.User;
 
@@ -9,6 +10,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,17 +26,29 @@ public class SearchHistoryController {
     private final SearchHistoryService searchHistoryService;
 
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public void saveSearchKeyword(@UserLogin User user, @Valid @NotBlank @RequestParam String keyword) {
+    public ResponseEntity<String> saveAndPerformSearch(@UserLogin User user, @Valid @NotBlank @RequestParam("keyword") String keyword) {
+        // 검색어 저장
         searchHistoryService.saveSearchKeyword(user.getId(), keyword);
-        log.info("User ID {}의 검색어 '{}'가 저장되었습니다.", user.getId(), keyword);
+        log.info("UserID '{}'의 검색어 [{}] 저장되었습니다.", user.getId(), keyword);
+
+        // 검색 실행
+        SearchResults results = searchHistoryService.performSearch(keyword);
+        if (results.getNames().isEmpty()) {
+            String message = "검색어 [" + keyword + "]은 존재하지 않습니다.";
+            log.info(message);
+            return new ResponseEntity<>(message, HttpStatus.OK);
+
+        }
+        String formattedResults = "연관 검색어 : " + String.join(", ", results.getNames());
+        log.info("{}", formattedResults);
+        return new ResponseEntity<>(formattedResults, HttpStatus.OK);
     }
+
 
     @GetMapping("/recent")
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getRecentSearchKeywords(@UserLogin User user) {
         Set<String> recentKeywords = searchHistoryService.getRecentSearchKeywords(user.getId());
-
         log.info("User ID {}의 최근 검색어를 조회하였습니다: {}", user.getId(), recentKeywords);
         return recentKeywords;
     }

--- a/src/main/java/com/farm/pedia/searchHistory/controller/SearchHistoryController.java
+++ b/src/main/java/com/farm/pedia/searchHistory/controller/SearchHistoryController.java
@@ -9,7 +9,6 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,45 +27,32 @@ public class SearchHistoryController {
 
     // 자동 완성
     @GetMapping("/autocomplete")
-    public ResponseEntity<List<Map<String, Object>>> autocomplete(@RequestParam("keyword") String keyword) {
-        if (keyword == null || keyword.trim().isEmpty()) {
-            return new ResponseEntity<>(List.of(), HttpStatus.OK);
-        }
-        List<Map<String, Object>> results = searchHistoryService.autocomplete(keyword);
-        return new ResponseEntity<>(results, HttpStatus.OK);
+    @ResponseStatus(HttpStatus.OK)
+    public List<Map<String, Object>> autocomplete(@RequestParam("keyword") String keyword) {
+		return searchHistoryService.autocomplete(keyword);
     }
     // 자동완성 리스트 내 항목 이름 저장 & 상세 정보 가져오기
     @PostMapping("/select")
-    public ResponseEntity<Map<String, Object>> selectAndSave(@UserLogin User user, @Valid @NotBlank @RequestParam("name") String name) {
+    @ResponseStatus(HttpStatus.OK)
+    public Map<String, Object> selectAndSave(@UserLogin User user, @Valid @NotBlank(message = "검색은 2글자 이상만 가능합니다.") @RequestParam("name") String name) {
         Map<String, Object> result = searchHistoryService.getDetailsAndSave(user.getId(), name);
-        if (result.isEmpty()) {
-            log.info("선택한 항목 [{}]은 존재하지 않습니다.", name);
-            return new ResponseEntity<>(result, HttpStatus.OK);
-        }
         log.info("선택한 항목의 상세 정보: {}", result);
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return result;
     }
 
 
     // 검색 & 상세 정보 가져오기
     @PostMapping
-    public ResponseEntity<List<Map<String, Object>>> searchAndSave(@UserLogin User user, @Valid @NotBlank @RequestParam("keyword") String keyword) {
-        // 검색어가 공백만으로 이루어져 있을 경우 빈 리스트 반환
-        if (keyword == null || keyword.trim().isEmpty()) {
-            return new ResponseEntity<>(List.of(), HttpStatus.OK);
-        }
-
+    @ResponseStatus(HttpStatus.OK)
+    public List<Map<String, Object>> searchAndSave(@UserLogin User user, @Valid @NotBlank(message = "검색은 2글자 이상만 가능합니다.") String keyword) {
         // 검색어 저장
         searchHistoryService.saveSearchKeyword(user.getId(), keyword);
 
         // 검색 실행
         List<Map<String, Object>> results = searchHistoryService.search(keyword);
-        if (results.isEmpty()) {
-            log.info("검색어 [{}]은 존재하지 않습니다.", keyword);
-            return new ResponseEntity<>(results, HttpStatus.OK);
-        }
+
         log.info("검색 결과: {}", results);
-        return new ResponseEntity<>(results, HttpStatus.OK);
+        return results;
     }
 
 

--- a/src/main/java/com/farm/pedia/searchHistory/domain/SearchResults.java
+++ b/src/main/java/com/farm/pedia/searchHistory/domain/SearchResults.java
@@ -1,0 +1,24 @@
+package com.farm.pedia.searchHistory.domain;
+
+import java.util.List;
+
+public class SearchResults {
+    private List<String> names;
+
+    public SearchResults(List<String> names) {
+        this.names = names;
+    }
+
+    @Override
+    public String toString() {
+        return names.toString();
+    }
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public void setNames(List<String> names) {
+        this.names = names;
+    }
+}

--- a/src/main/java/com/farm/pedia/searchHistory/impl/SearchHistoryServiceImpl.java
+++ b/src/main/java/com/farm/pedia/searchHistory/impl/SearchHistoryServiceImpl.java
@@ -1,0 +1,89 @@
+package com.farm.pedia.searchHistory.impl;
+
+import com.farm.pedia.searchHistory.mapper.SearchHistoryMapper;
+import com.farm.pedia.searchHistory.service.SearchHistoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SearchHistoryServiceImpl implements SearchHistoryService {
+
+    private static final String REDIS_RECENT_SEARCH_KEY = "recentSearch:";
+    private final SearchHistoryMapper searchHistoryMapper;
+    private final RedisTemplate<String, String> redisTemplate;
+    SearchHistoryService self;
+
+    @Transactional
+    @Override
+    public void saveSearchKeyword(Long userId, String keyword) {
+        // Redis 검색 키워드 저장
+        String redisKey = REDIS_RECENT_SEARCH_KEY + userId;
+        redisTemplate.opsForZSet().add(redisKey, keyword, System.currentTimeMillis());
+        redisTemplate.opsForZSet().removeRange(redisKey, 0, -6); // 최신 5개
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Map<String, Object>> autocomplete(String keyword) {
+        List<Map<String, Object>> varietyNames = searchHistoryMapper.searchVarietyName(keyword);
+        List<Map<String, Object>> cropNames = searchHistoryMapper.searchCropsName(keyword);
+        varietyNames.addAll(cropNames);
+        varietyNames.sort(Comparator.comparing(map -> (String) map.get("name")));
+        return varietyNames;
+    }
+
+    @Transactional
+    @Override
+    public Map<String, Object> getDetailsAndSave(Long userId, String name) {
+        // 검색어 저장
+
+        self.saveSearchKeyword(userId, name);
+
+        // variety 테이블에서 검색
+        Map<String, Object> varietyDetails = searchHistoryMapper.getVarietyDetailsByName(name);
+        if (!varietyDetails.isEmpty()) {
+            return varietyDetails;
+        }
+
+        // crops 테이블에서 검색
+        Map<String, Object> cropsDetails = searchHistoryMapper.getCropsDetailsByName(name);
+        if (!cropsDetails.isEmpty()) {
+            return cropsDetails;
+        }
+        return Map.of();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Map<String, Object>> search(String keyword) {
+        List<Map<String, Object>> varietyNames = searchHistoryMapper.searchVarietyDetails(keyword);
+        List<Map<String, Object>> cropNames = searchHistoryMapper.searchCropsDetails(keyword);
+        varietyNames.addAll(cropNames);
+        varietyNames.sort(Comparator.comparing(map -> (String) map.get("name")));
+        return varietyNames;
+    }
+
+    @Override
+    public Set<String> getRecentSearchKeywords(Long userId) {
+        String redisKey = REDIS_RECENT_SEARCH_KEY + userId;
+        log.debug("Fetching recent search keywords for userId: {}", userId);
+        return redisTemplate.opsForZSet().reverseRange(redisKey, 0, 4);
+    }
+
+    @Override
+    public void deleteSearchKeyword(Long userId, String keyword) {
+        String redisKey = REDIS_RECENT_SEARCH_KEY + userId;
+        log.debug("Deleting search keyword: {} for userId: {}", keyword, userId);
+        redisTemplate.opsForZSet().remove(redisKey, keyword);
+    }
+}

--- a/src/main/java/com/farm/pedia/searchHistory/mapper/SearchHistoryMapper.java
+++ b/src/main/java/com/farm/pedia/searchHistory/mapper/SearchHistoryMapper.java
@@ -1,10 +1,17 @@
 package com.farm.pedia.searchHistory.mapper;
 
 import com.farm.pedia.searchHistory.domain.SearchHistory;
-import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface SearchHistoryMapper {
 
     void save(SearchHistory searchHistory);
+
+    List<String> searchVarietyByName(@Param("keyword") String keyword);
+
+    List<String> searchCropsByVarietyName(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/farm/pedia/searchHistory/mapper/SearchHistoryMapper.java
+++ b/src/main/java/com/farm/pedia/searchHistory/mapper/SearchHistoryMapper.java
@@ -5,13 +5,22 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Map;
 
 @Mapper
 public interface SearchHistoryMapper {
 
     void save(SearchHistory searchHistory);
 
-    List<String> searchVarietyByName(@Param("keyword") String keyword);
+    // 자동 완성 - id, name만 return
+    List<Map<String, Object>> searchVarietyDetails(@Param("keyword") String keyword);
+    List<Map<String, Object>> searchCropsDetails(@Param("keyword") String keyword);
 
-    List<String> searchCropsByVarietyName(@Param("keyword") String keyword);
+    // 검색 버튼 시 (백과사전) - id, name, cropsname(category), imageUrl
+    List<Map<String, Object>> searchVarietyName(@Param("keyword") String keyword);
+    List<Map<String, Object>> searchCropsName(@Param("keyword") String keyword);
+
+    // 자동완성 리스트 내 항목 클릭 - id, name, cropsname(category), imageUrl
+    Map<String, Object> getVarietyDetailsByName(@Param("name") String name);
+    Map<String, Object> getCropsDetailsByName(@Param("name") String name);
 }

--- a/src/main/java/com/farm/pedia/searchHistory/service/SearchHistoryService.java
+++ b/src/main/java/com/farm/pedia/searchHistory/service/SearchHistoryService.java
@@ -1,61 +1,14 @@
 package com.farm.pedia.searchHistory.service;
 
-import com.farm.pedia.searchHistory.domain.SearchResults;
-import com.farm.pedia.searchHistory.mapper.SearchHistoryMapper;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
-@Service
-@RequiredArgsConstructor
-@Slf4j
-public class SearchHistoryService {
-
-    private static final String REDIS_RECENT_SEARCH_KEY = "recentSearch:";
-    private final SearchHistoryMapper searchHistoryMapper;
-    private final RedisTemplate<String, String> redisTemplate;
-
-    @Transactional
-    // 검색어 저장 (검색어 입력 시 즉시 저장)
-    public void saveSearchKeyword(Long userId, String keyword) {
-        // Redis 검색 키워드 저장
-        String redisKey = REDIS_RECENT_SEARCH_KEY + userId;
-        redisTemplate.opsForZSet().add(redisKey, keyword, System.currentTimeMillis());
-        redisTemplate.opsForZSet().removeRange(redisKey, 0, -6); // 최신 5개
-    }
-
-    // 키워드 검색 수행
-    public SearchResults performSearch(String keyword) {
-        log.debug("키워드 [{}]의 검색 시작", keyword);
-
-        // 품종 명으로 검색
-        List<String> varietyNames = searchHistoryMapper.searchVarietyByName(keyword);
-
-        // 일치하는 품종 명이 없을 시 카테고리로 검색
-        if (varietyNames.isEmpty()) {
-            List<String> cropsNames = searchHistoryMapper.searchCropsByVarietyName(keyword);
-            log.debug("검색어와 일치하는 카테고리 : {}", cropsNames);
-            return new SearchResults(cropsNames);
-        }
-        return new SearchResults(varietyNames);
-    }
-
-    // 최근 검색어
-    public Set<String> getRecentSearchKeywords(Long userId) {
-        String redisKey = REDIS_RECENT_SEARCH_KEY + userId;
-        log.debug("Fetching recent search keywords for userId: {}", userId);
-        return redisTemplate.opsForZSet().reverseRange(redisKey, 0, 4);
-    }
-
-    // 검색어 삭제
-    public void deleteSearchKeyword(Long userId, String keyword) {
-        String redisKey = REDIS_RECENT_SEARCH_KEY + userId;
-        log.debug("Deleting search keyword: {} for userId: {}", keyword, userId);
-        redisTemplate.opsForZSet().remove(redisKey, keyword);
-    }
+public interface SearchHistoryService {
+    void saveSearchKeyword(Long userId, String keyword);
+    List<Map<String, Object>> autocomplete(String keyword);
+    List<Map<String, Object>> search(String keyword);
+    Map<String, Object> getDetailsAndSave(Long userId, String name);
+    Set<String> getRecentSearchKeywords(Long userId);
+    void deleteSearchKeyword(Long userId, String keyword);
 }

--- a/src/main/java/com/farm/pedia/searchHistory/service/SearchHistoryService.java
+++ b/src/main/java/com/farm/pedia/searchHistory/service/SearchHistoryService.java
@@ -1,41 +1,61 @@
 package com.farm.pedia.searchHistory.service;
 
-import com.farm.pedia.searchHistory.domain.SearchHistory;
+import com.farm.pedia.searchHistory.domain.SearchResults;
 import com.farm.pedia.searchHistory.mapper.SearchHistoryMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SearchHistoryService {
 
     private static final String REDIS_RECENT_SEARCH_KEY = "recentSearch:";
-
     private final SearchHistoryMapper searchHistoryMapper;
     private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
+    // 검색어 저장 (검색어 입력 시 즉시 저장)
     public void saveSearchKeyword(Long userId, String keyword) {
-        SearchHistory searchHistory = SearchHistory.of(keyword, userId);
-        searchHistoryMapper.save(searchHistory);
-
-        // Redis에 저장
+        // Redis 검색 키워드 저장
         String redisKey = REDIS_RECENT_SEARCH_KEY + userId;
         redisTemplate.opsForZSet().add(redisKey, keyword, System.currentTimeMillis());
-        redisTemplate.opsForZSet().removeRange(redisKey, 0, -6); // 최신 5개만 유지
+        redisTemplate.opsForZSet().removeRange(redisKey, 0, -6); // 최신 5개
     }
 
+    // 키워드 검색 수행
+    public SearchResults performSearch(String keyword) {
+        log.debug("키워드 [{}]의 검색 시작", keyword);
+
+        // 품종 명으로 검색
+        List<String> varietyNames = searchHistoryMapper.searchVarietyByName(keyword);
+
+        // 일치하는 품종 명이 없을 시 카테고리로 검색
+        if (varietyNames.isEmpty()) {
+            List<String> cropsNames = searchHistoryMapper.searchCropsByVarietyName(keyword);
+            log.debug("검색어와 일치하는 카테고리 : {}", cropsNames);
+            return new SearchResults(cropsNames);
+        }
+        return new SearchResults(varietyNames);
+    }
+
+    // 최근 검색어
     public Set<String> getRecentSearchKeywords(Long userId) {
         String redisKey = REDIS_RECENT_SEARCH_KEY + userId;
+        log.debug("Fetching recent search keywords for userId: {}", userId);
         return redisTemplate.opsForZSet().reverseRange(redisKey, 0, 4);
     }
 
+    // 검색어 삭제
     public void deleteSearchKeyword(Long userId, String keyword) {
         String redisKey = REDIS_RECENT_SEARCH_KEY + userId;
+        log.debug("Deleting search keyword: {} for userId: {}", keyword, userId);
         redisTemplate.opsForZSet().remove(redisKey, keyword);
     }
 }

--- a/src/main/java/com/farm/pedia/searchHistory/service/impl/SearchHistoryServiceImpl.java
+++ b/src/main/java/com/farm/pedia/searchHistory/service/impl/SearchHistoryServiceImpl.java
@@ -35,6 +35,9 @@ public class SearchHistoryServiceImpl implements SearchHistoryService {
     @Transactional(readOnly = true)
     @Override
     public List<Map<String, Object>> autocomplete(String keyword) {
+        if (keyword.isEmpty()) {
+            return List.of();
+        }
         List<Map<String, Object>> varietyNames = searchHistoryMapper.searchVarietyName(keyword);
         List<Map<String, Object>> cropNames = searchHistoryMapper.searchCropsName(keyword);
         varietyNames.addAll(cropNames);

--- a/src/main/java/com/farm/pedia/searchHistory/service/impl/SearchHistoryServiceImpl.java
+++ b/src/main/java/com/farm/pedia/searchHistory/service/impl/SearchHistoryServiceImpl.java
@@ -1,4 +1,4 @@
-package com.farm.pedia.searchHistory.impl;
+package com.farm.pedia.searchHistory.service.impl;
 
 import com.farm.pedia.searchHistory.mapper.SearchHistoryMapper;
 import com.farm.pedia.searchHistory.service.SearchHistoryService;

--- a/src/main/resources/mappers/searchHistory/SearchHistoryMapper.xml
+++ b/src/main/resources/mappers/searchHistory/SearchHistoryMapper.xml
@@ -7,24 +7,52 @@
         VALUES (#{keyword}, #{searchedAt}, #{userId})
     </insert>
 
-<!--  품종 명으로 검색  -->
-    <select id="searchVarietyByName" parameterType="String" resultType="String">
-        SELECT name
-        FROM crops
-        WHERE id IN (
-            SELECT crops_id
-            FROM variety
-            WHERE name = #{keyword}
-        )
+
+    <!-- 자동 완성 쿼리: id와 name만 반환 -->
+    <!-- 품종 명으로 검색 -->
+    <select id="searchVarietyName" parameterType="String" resultType="map">
+        SELECT v.id as id, v.name as name
+        FROM variety v
+        WHERE v.name LIKE CONCAT('%', #{keyword}, '%')
+    </select>
+    <!-- 카테고리로 검색 -->
+    <select id="searchCropsName" parameterType="String" resultType="map">
+        SELECT c.id as id, c.name as name
+        FROM crops c
+        WHERE c.name LIKE CONCAT('%', #{keyword}, '%')
     </select>
 
-<!--  카테고리로 검색  -->
-    <select id="searchCropsByVarietyName" parameterType="String" resultType="String">
-        SELECT name
-        FROM crops
-        WHERE name = #{keyword}
+
+    <!-- 검색 쿼리: 모든 필드 반환 -->
+    <!-- 품종 명으로 검색 -->
+    <select id="searchVarietyDetails" parameterType="String" resultType="map">
+        SELECT v.id as id, v.name as name, v.image_url as imageUrl, c.name as cropName
+        FROM variety v
+                 JOIN crops c ON v.crops_id = c.id
+        WHERE v.name LIKE CONCAT('%', #{keyword}, '%')
+    </select>
+    <!-- 카테고리로 검색 -->
+    <select id="searchCropsDetails" parameterType="String" resultType="map">
+        SELECT c.id as id, c.name as name, c.image_url as imageUrl
+        FROM crops c
+        WHERE c.name LIKE CONCAT('%', #{keyword}, '%')
     </select>
 
+
+
+    <!-- 자동완성 리스트 내 항목 클릭 시 -->
+    <select id="getVarietyDetailsByName" parameterType="String" resultType="map">
+        SELECT v.id as id, v.name as name, v.image_url as imageUrl, c.name as cropName
+        FROM variety v
+                 JOIN crops c ON v.crops_id = c.id
+        WHERE v.name = #{name}
+    </select>
+
+    <select id="getCropsDetailsByName" parameterType="String" resultType="map">
+        SELECT c.id as id, c.name as cropName, c.image_url as imageUrl
+        FROM crops c
+        WHERE c.name = #{name}
+    </select>
 </mapper>
 
 

--- a/src/main/resources/mappers/searchHistory/SearchHistoryMapper.xml
+++ b/src/main/resources/mappers/searchHistory/SearchHistoryMapper.xml
@@ -6,4 +6,28 @@
         INSERT INTO search_history (keyword, searched_at, user_id)
         VALUES (#{keyword}, #{searchedAt}, #{userId})
     </insert>
+
+<!--  품종 명으로 검색  -->
+    <select id="searchVarietyByName" parameterType="String" resultType="String">
+        SELECT name
+        FROM crops
+        WHERE id IN (
+            SELECT crops_id
+            FROM variety
+            WHERE name = #{keyword}
+        )
+    </select>
+
+<!--  카테고리로 검색  -->
+    <select id="searchCropsByVarietyName" parameterType="String" resultType="String">
+        SELECT name
+        FROM crops
+        WHERE name = #{keyword}
+    </select>
+
 </mapper>
+
+
+
+
+


### PR DESCRIPTION
- [x] **연관 검색어 기능  + 자동완성 기능** 
- 기존 검색어 저장 기능 다음과 같이 수정
_______________________________________________________

✅  자동완성
- '블'을 입력하면 실시간으로 '블'이 포함된 단어가 list로 반환 (name, id) 
- 프론트 상 출력은 name만 
- 정보가 존재하지 않을 시 : 빈리스트 return

✅  검색어 저장 - Redis
- '블'을 입력하고 검색 버튼을 누르면 '블'이라는 단어가 Redis에 저장
- 자동 완성 리스트 내 항목 클릭 시 클릭한 항목의 name이 Redis에 저장

✅  백과사전 출력 - 상세정보 출력
- 가나다 순 출력
- 정보가 존재하지 않을 시 : 빈리스트 return
- '감'을 입력하고 검색 버튼을 클릭하면 다음과 같이 '감'이라는 단어가 포함된 정보가 return
- [{"imageUrl": "이미지주소",
    "name": "감귤",
    "id": 7},
   {"imageUrl": "이미지주소",
    "name": "감로",
    "cropName": "사과",
    "id": 3}]
- 자동 완성 목록에서 항목을 클릭하면 해당 항목에 대한 정보만 return

✅  공백 검색 시 
1. 자동완성 
    - 빈리스트 return
    
2. 검색 버튼 클릭 시 
    - 빈리스트 return 
    - 로그에 예외 기록 